### PR TITLE
Add download page

### DIFF
--- a/assets/css/download-latest.css
+++ b/assets/css/download-latest.css
@@ -10,7 +10,7 @@ header a.logo {
     top: 15rem;
 }
     .version h1 {
-        font-size: 10rem;
+        font-size: 8rem;
         font-style: italic;
         font-weight: bold;
         /*color: rgb(45,144,233);*/

--- a/content/download/contents.lr
+++ b/content/download/contents.lr
@@ -1,0 +1,95 @@
+title: FreedomBox Download
+---
+release_name: testing
+---
+release_date: 2016-07-03
+---
+images_hardware_targets:
+
+Cubietruck
+Cubieboard2
+BeagleBone Black
+A20 OLinuXino Lime
+A20 OLinuXino Lime2
+A20 OLinuXino MICRO
+DreamPlug
+Raspberry Pi
+Raspberry Pi 2/3
+64-bit x86 (amd64)
+32-bit x86 (i386)
+Qemu 64-bit
+Qemu 32-bit
+VirtualBox 64-bit
+VirtualBox 32-bit
+---
+images_tags:
+
+2016-07-03 armhf testing free
+2016-07-03 armhf testing free
+2016-07-03 armhf testing free
+2016-07-03 armhf testing free
+2016-07-03 armhf testing free
+2016-07-03 armhf testing free
+2016-07-03 armel testing free
+2016-07-03 armel testing nonfree
+2016-07-03 armhf testing nonfree
+2016-07-02 amd64 testing free
+2016-07-02 i386 testing free
+2016-07-02 amd64 testing free
+2016-07-02 i386 testing free
+2016-07-02 amd64 testing free
+2016-07-02 i386 testing free
+---
+images_filenames:
+
+freedombox-testing-free_0.9_cubietruck-armhf.img.xz
+freedombox-testing-free_0.9_cubieboard2-armhf.img.xz
+freedombox-testing-free_0.9_beaglebone-armhf.img.xz
+freedombox-testing-free_0.9_a20-olinuxino-lime-armhf.img.xz
+freedombox-testing-free_0.9_a20-olinuxino-lime2-armhf.img.xz
+freedombox-testing-free_0.9_a20-olinuxino-micro-armhf.img.xz
+freedombox-testing-free_0.9_dreamplug-armel.img.xz
+freedombox-testing-nonfree_0.9_raspberry-armel.img.xz
+freedombox-testing-nonfree_0.9_raspberry2-armhf.img.xz
+freedombox-testing-free_0.9_all-amd64.img.xz
+freedombox-testing-free_0.9_all-i386.img.xz
+freedombox-testing-free_0.9_all-amd64.qcow2.xz
+freedombox-testing-free_0.9_all-i386.qcow2.xz
+freedombox-testing-free_0.9_all-amd64.vdi.xz
+freedombox-testing-free_0.9_all-i386.vdi.xz
+---
+images_signatures_filenames:
+
+freedombox-testing-free_0.9_cubietruck-armhf.img.xz.sig
+freedombox-testing-free_0.9_cubieboard2-armhf.img.xz.sig
+freedombox-testing-free_0.9_beaglebone-armhf.img.xz.sig
+freedombox-testing-free_0.9_a20-olinuxino-lime-armhf.img.xz.sig
+freedombox-testing-free_0.9_a20-olinuxino-lime2-armhf.img.xz.sig
+freedombox-testing-free_0.9_a20-olinuxino-micro-armhf.img.xz.sig
+freedombox-testing-free_0.9_dreamplug-armel.img.xz.sig
+freedombox-testing-nonfree_0.9_raspberry-armel.img.xz.sig
+freedombox-testing-nonfree_0.9_raspberry2-armhf.img.xz.sig
+freedombox-testing-free_0.9_all-amd64.img.xz.sig
+freedombox-testing-free_0.9_all-i386.img.xz.sig
+freedombox-testing-free_0.9_all-amd64.qcow2.xz.sig
+freedombox-testing-free_0.9_all-i386.qcow2.xz.sig
+freedombox-testing-free_0.9_all-amd64.vdi.xz.sig
+freedombox-testing-free_0.9_all-i386.vdi.xz.sig
+---
+images_sizes:
+
+242
+242
+241
+242
+242
+241
+221
+287
+376
+246
+245
+243
+243
+243
+243

--- a/models/download.ini
+++ b/models/download.ini
@@ -1,0 +1,35 @@
+[model]
+name = Download
+label = {{ this.title }}
+
+[fields.title]
+label = Title
+type = string
+
+[fields.release_name]
+label = Release name
+type = string
+
+[fields.release_date]
+label = Release date
+type = string
+
+[fields.images_hardware_targets]
+label = Images hardware targets
+type = strings
+
+[fields.images_tags]
+label = Images tags
+type = strings
+
+[fields.images_filenames]
+label = Images filenames
+type = strings
+
+[fields.images_sizes]
+label = Images sizes
+type = strings
+
+[fields.images_signatures_filenames]
+label = Images signatures filenames
+type = strings

--- a/templates/download.html
+++ b/templates/download.html
@@ -1,0 +1,43 @@
+{% extends "layout.html" %}
+
+{% block page_css %}
+  <link rel="stylesheet" href="{{ '/css/download-latest.css'|asseturl }}">
+{% endblock %}
+
+{% block heading %}
+  <h1 class="headlinegroup">how to <em>download FreedomBox</em></h1>
+{% endblock %}
+
+{% block menu %}
+  <div class="version">
+    <h1>{{ this.release_name }}</h1>
+    <date>{{ this.release_date }}</date>
+    <a href="http://ftp.freedombox.org/pub/freedombox/"
+       class="greenbutton">all versions</a>
+  </div>
+{% endblock %}
+
+{% block content %}
+
+  <table class="img">
+    {% for image_hardware_target in this.images_hardware_targets %}
+    <tr>
+      <td>
+        <h2>{{ image_hardware_target }}</h2>
+        {{ this.images_tags[loop.index-1] }}
+      </td>
+      <td>
+        <a href="http://ftp.freedombox.org/pub/freedombox/0.9/{{ this.images_filenames[loop.index-1] }}" class="bluebutton">
+	  testing img <em>{{ this.images_sizes[loop.index-1] }}</em></a>
+        <a href="http://ftp.freedombox.org/pub/freedombox/0.9/{{ this.images_signatures_filenames[loop.index-1] }}" class="signature">signature</a>
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+
+  <div class="lastlink">
+  <a href="https://wiki.debian.org/FreedomBox/Download"
+     class="greenbutton">how to verify and install</a>
+  </div>
+
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -3,14 +3,16 @@
 <head>
   <meta charset="utf-8">
 
-  <title>{% block title %}FreedomBox{% endblock %} - freedombox.org</title>
+  <title>{% block title %}{{ this.title }}{% endblock %} - freedombox.org</title>
 
   <link rel="stylesheet" href="{{ '/css/reset.css'|asseturl }}">
   <link rel="stylesheet" href="{{ '/css/latolatinfonts.css'|asseturl }}">
   <link rel="stylesheet" href="{{ '/css/main.css'|asseturl }}">
   <link rel="stylesheet" href="{{ '/css/animated-logo.css'|asseturl }}">
 
-  <link rel="stylesheet" href="{{ '/css/landing.css'|asseturl }}">
+  {% block page_css %}
+    <link rel="stylesheet" href="{{ '/css/landing.css'|asseturl }}">
+  {% endblock %}
 </head>
 
 <body>
@@ -29,14 +31,20 @@
   <div class="main">
     <div class="container">
 
-      <div class="buttons">
-        <a href="https://wiki.debian.org/FreedomBox/Download" class="download">
-	  download</a>
-      </div>
+      {% block heading %}
+      {% endblock %}
 
-      <div class="description">
-	<p>{% block body %}{% endblock %}</p>
+      {% block menu %}
+      <div class="buttons">
+        <a href="{{ '/download'|url }}" class="download">download</a>
       </div>
+      {% endblock %}
+
+      {% block content %}
+      <div class="description">
+	<p>{{ this.body }}</p>
+      </div>
+      {% endblock %}
 
       <div class="background-box"></div>
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
-{% block title %}{{ this.title }}{% endblock %}
-
-{% block body %}
-  {{ this.body }}
+{% block content %}
+  <div class="description">
+    <p>{{ this.body }}</p>
+  </div>
 {% endblock %}


### PR DESCRIPTION
 - Reduce size of release/version name. I used "testing" instead of "0.9", so it takes up more space.
 - Add link from landing page to download page.
 - Add links to verify/install instructions on wiki.

There's one issue, when the browser window is narrow, the release/version name will overlap the list of images.

I have the generated pages up at https://jvalleroy.mooo.com/~jvalleroy/freedombox/landing_page_staging/ if anyone wants to see how it looks now.