### PR TITLE
Add about page

### DIFF
--- a/content/about/contents.lr
+++ b/content/about/contents.lr
@@ -1,0 +1,18 @@
+title: About FreedomBox
+---
+body:
+
+FreedomBox is a joined effort of people to regain control and privacy
+in the digital world by dragging it into the physical. Our vision is
+to use free software running on cheap hardware to replace services
+that are not under our control. Today's cost of CPU power and network
+bandwidth make hosting your own services affordable.
+
+We unite the efforts of countless contributors from the free software
+world by building on top of Debian GNU/Linux. Our biggest contribution
+is to be the easy to use administration tool that takes care of
+otherwise challenging administrative tasks to keep your FreedomBox
+updated and running.
+
+If you want to join the effort of our volunteers or support the
+non-profit Foundation behind them – get in touch with us.

--- a/models/about.ini
+++ b/models/about.ini
@@ -1,0 +1,11 @@
+[model]
+name = About
+label = {{ this.title }}
+
+[fields.title]
+label = Title
+type = string
+
+[fields.body]
+label = Body
+type = markdown

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+
+{% block page_css %}
+  <link rel="stylesheet" href="{{ '/css/about.css'|asseturl }}">
+{% endblock %}
+
+{% block menu %}
+{% endblock %}
+
+{% block content %}
+<div class="about">
+  <p>{{ this.body }}</p>
+</div>
+{% endblock %}
+
+{% block bottom_menu %}
+  <div class="buttons">
+    <a href="{{ '/download'|url }}" class="bigbluebutton">download</a>
+  </div>
+{% endblock %}
+
+{% block background %}
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -46,7 +46,15 @@
       </div>
       {% endblock %}
 
+      {% block bottom_menu %}
+      <div class="description">
+        <a href="{{ '/about'|url }}" class="greenbutton">more about our project</a>
+      </div>
+      {% endblock %}
+
+      {% block background %}
       <div class="background-box"></div>
+      {% endblock %}
 
     </div>
   </div>


### PR DESCRIPTION
Using text developed in #7:
![about](https://user-images.githubusercontent.com/178876/29664093-3b60090c-889c-11e7-816e-9d8536025510.png)

Here is the modified landing page ("more" button links to about page):
![landing_more](https://user-images.githubusercontent.com/178876/29664096-3f4a3dc6-889c-11e7-9d75-fc03942c8ccb.png)